### PR TITLE
Refactor test setup in user-handler_test.go to use filepath for CQL s…

### DIFF
--- a/packages/user/handler/user-handler_test.go
+++ b/packages/user/handler/user-handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -84,7 +85,8 @@ func createTestContainer(ctx context.Context) (*cassandra.CassandraContainer, er
 		return nil, fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	cqlScripts := workingDir + "/packages/db/testdata/init.cql"
+	repoRoot := filepath.Join(workingDir, "..", "..")
+	cqlScripts := filepath.Join(repoRoot, "packages", "db", "testdata", "init.cql")
 
 	cassandraContainer, err := cassandra.Run(
 		ctx,


### PR DESCRIPTION
…cript path

- Updated the path construction for the CQL scripts in the test setup to utilize filepath.Join for better cross-platform compatibility.