### PR TITLE
Update unit-integration workflow and auth controller for local Cassan…

### DIFF
--- a/.github/workflows/unit-integration.yml
+++ b/.github/workflows/unit-integration.yml
@@ -72,6 +72,8 @@ jobs:
     strategy:
       matrix:
         modules: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
+    env:
+      CASSANDRA_LOCAL: "true"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/packages/auth/controller/auth-controller.go
+++ b/packages/auth/controller/auth-controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -35,7 +36,12 @@ func NewAuthController(ctx context.Context, cfg *config.Config, reg *prometheus.
 		RefreshTokenStore: rts,
 	}
 
-	c.Db = database.ConnectAstra(cfg, token)
+	if os.Getenv("CASSANDRA_LOCAL") == "true" {
+		// Use the same host/port as your test setup
+		c.Db = database.ConnectLocal("127.0.0.1", 9092)
+	} else {
+		c.Db = database.ConnectAstra(cfg, token)
+	}
 	return c
 }
 


### PR DESCRIPTION
…dra support

- Added an environment variable to the unit-integration workflow to enable local Cassandra configuration.
- Modified the auth controller to connect to a local Cassandra instance when the environment variable CASSANDRA_LOCAL is set to true, ensuring compatibility with local testing setups.